### PR TITLE
Move error.log

### DIFF
--- a/ext/lb/nginx/template.go
+++ b/ext/lb/nginx/template.go
@@ -5,7 +5,7 @@ user  {{ .Config.User }};
 worker_processes  {{ .Config.WorkerProcesses }};
 worker_rlimit_nofile {{ .Config.RLimitNoFile }};
 
-error_log  /var/log/error.log warn;
+error_log  /var/log/nginx/error.log warn;
 pid        {{ .Config.PidPath }};
 
 


### PR DESCRIPTION
This is where the container links expect it to go.